### PR TITLE
Remove Backdoor Roth from taxable-income deductions and UI

### DIFF
--- a/backend/api/calculator.py
+++ b/backend/api/calculator.py
@@ -43,7 +43,6 @@ def calculate_fire_projection(data):
     retirement_spending = data['retirementSpending']
     withdrawal_rate = data['withdrawalRate'] / 100
     pre_tax_401k = data['preTax401k']
-    backdoor_roth = data.get('backdoorRoth', 0)
     employer_match = data['employerMatch'] / 100
     country = data.get('country', 'US')
     state = data.get('state', 'CA')
@@ -78,7 +77,7 @@ def calculate_fire_projection(data):
         )
 
         total_available_income, effective_tax_rate, _ = calculate_income_tax(
-            gross_income, state, pre_tax_401k, employer_match, country, filing_status, backdoor_roth
+            gross_income, state, pre_tax_401k, employer_match, country, filing_status
         )
 
         _, real_interest_earned = calculate_net_worth(
@@ -105,7 +104,7 @@ def calculate_fire_projection(data):
         )
 
         total_available_income, effective_tax_rate, _ = calculate_income_tax(
-            gross_income, state, pre_tax_401k, employer_match, country, filing_status, backdoor_roth
+            gross_income, state, pre_tax_401k, employer_match, country, filing_status
         )
 
         _, real_interest_earned = calculate_net_worth(

--- a/backend/api/tax.py
+++ b/backend/api/tax.py
@@ -110,7 +110,7 @@ def calculate_tax_for_bracket(income, brackets):
     return tax
 
 
-def calculate_income_tax(income, state, pre_tax_401k, employer_match, country_code='US', filing_status='single', backdoor_roth=0):
+def calculate_income_tax(income, state, pre_tax_401k, employer_match, country_code='US', filing_status='single'):
     """
     Calculate income tax for the calculator.
 
@@ -121,7 +121,6 @@ def calculate_income_tax(income, state, pre_tax_401k, employer_match, country_co
         employer_match: Employer match rate (decimal)
         country_code: Two-letter country code
         filing_status: Filing status ('single' or 'married')
-        backdoor_roth: Backdoor Roth contribution amount (modeled as reducing taxable income)
 
     Returns:
         (total_available_income, effective_tax_rate, tax_breakdown)
@@ -142,9 +141,8 @@ def calculate_income_tax(income, state, pre_tax_401k, employer_match, country_co
     federal_standard_deduction = federal_config.get('standard_deduction', 0)
     state_standard_deduction = state_config.get('standard_deduction', 0)
 
-    retirement_deduction = pre_tax_401k + backdoor_roth
-    federal_taxable_income = max(0, income - retirement_deduction - federal_standard_deduction)
-    state_taxable_income = max(0, income - retirement_deduction - state_standard_deduction)
+    federal_taxable_income = max(0, income - pre_tax_401k - federal_standard_deduction)
+    state_taxable_income = max(0, income - pre_tax_401k - state_standard_deduction)
 
     # Calculate federal tax
     federal_brackets = federal_config.get('brackets', [])

--- a/backend/api/test_calculator.py
+++ b/backend/api/test_calculator.py
@@ -212,7 +212,6 @@ class TestCalculator(unittest.TestCase):
             'withdrawalRate': 4,
             'preTax401k': 0.1,
             'employerMatch': 6,
-            'backdoorRoth': 10,
             'state': 'CA',
             'stopAtFire': False,
             'yearlyIncome': [{'startAge': 30, 'endAge': 65, 'amount': 100000}],
@@ -229,7 +228,6 @@ class TestCalculator(unittest.TestCase):
             'withdrawalRate': 10,  # Unrealistic withdrawal rate
             'preTax401k': 0.1,
             'employerMatch': 6,
-            'backdoorRoth': 10,
             'state': 'CA',
             'stopAtFire': False,
             'yearlyIncome': [{'startAge': 30, 'endAge': 65, 'amount': 100000}],
@@ -246,7 +244,6 @@ class TestCalculator(unittest.TestCase):
             'withdrawalRate': 4,
             'preTax401k': 0.15,
             'employerMatch': 8,
-            'backdoorRoth': 15,
             'state': 'TX',
             'stopAtFire': True,
             'yearlyIncome': [{'startAge': 25, 'endAge': 40, 'amount': 200000}],  # Higher income
@@ -263,7 +260,6 @@ class TestCalculator(unittest.TestCase):
             'withdrawalRate': 4,
             'preTax401k': 0.1,
             'employerMatch': 6,
-            'backdoorRoth': 10,
             'state': 'CA',
             'stopAtFire': False,
             'yearlyIncome': [{'startAge': 30, 'endAge': 65, 'amount': 100000}],

--- a/backend/api/validation.py
+++ b/backend/api/validation.py
@@ -80,9 +80,6 @@ def validate_calculate_payload(data: Dict[str, Any]) -> None:
     # Optional
     if 'stopAtFire' in data:
         _require_bool('stopAtFire', data['stopAtFire'])
-    if 'backdoorRoth' in data:
-        _require_number('backdoorRoth', data['backdoorRoth'], min_value=0)
-
 
 def validate_us_tax_comparison_payload(data: Dict[str, Any]) -> None:
     if 'income' not in data:

--- a/src/components/FireCalculator.tsx
+++ b/src/components/FireCalculator.tsx
@@ -108,7 +108,6 @@ interface Inputs {
   country: string;
   state: string;
   preTax401k: number;
-  backdoorRoth: number;
   employerMatch: number;
   filingStatus: string;
 }
@@ -432,7 +431,6 @@ const FireCalculator: React.FC = () => {
         country: config.country || 'US',
         state: config.state,
         preTax401k: config.preTax401k,
-        backdoorRoth: config.backdoorRoth ?? 0,
         employerMatch: config.employerMatch,
         filingStatus: config.filingStatus || 'single'
       });
@@ -571,7 +569,6 @@ const FireCalculator: React.FC = () => {
           ...inputs,
           endAge: inputs.endAge,  // Keep API compatibility
           preTax401k: inputs.country === 'US' ? inputs.preTax401k : 0,
-          backdoorRoth: inputs.country === 'US' ? inputs.backdoorRoth : 0,
           employerMatch: inputs.country === 'US' ? inputs.employerMatch : 0,
           yearlySpending: yearlySpending.map(d => ({
             startAge: d.startAge,
@@ -609,7 +606,7 @@ const FireCalculator: React.FC = () => {
   const usContributionLimit = 72_000;
   const employerMatchRate = inputs.employerMatch / 100;
   const usTotalContribution = inputs.country === 'US'
-    ? (inputs.preTax401k * (1 + employerMatchRate)) + inputs.backdoorRoth
+    ? (inputs.preTax401k * (1 + employerMatchRate))
     : 0;
   const isOverUsContributionLimit = inputs.country === 'US' && usTotalContribution > usContributionLimit;
 
@@ -1125,20 +1122,6 @@ const FireCalculator: React.FC = () => {
                           value={inputs.employerMatch}
                           onChange={handleInputChange}
                           slotProps={{ htmlInput: { min: 0, max: 100 } }}
-                        />
-                      </Grid>
-                      <Grid item xs={12}>
-                        <TextField
-                          fullWidth
-                          label="Backdoor Roth Contribution"
-                          name="backdoorRoth"
-                          value={formatMonetaryValue(inputs.backdoorRoth)}
-                          onChange={handleMonetaryInputChange('backdoorRoth')}
-                          slotProps={{
-                            input: {
-                              startAdornment: <InputAdornment position="start">{getCurrencySymbol(inputs.country)}</InputAdornment>
-                            }
-                          }}
                         />
                       </Grid>
                     </Grid>

--- a/src/config/countries.ts
+++ b/src/config/countries.ts
@@ -17,7 +17,6 @@ export interface CountryConfig {
     country: string;
     state: string;
     preTax401k: number;
-    backdoorRoth: number;
     employerMatch: number;
     filingStatus: string;
   };
@@ -49,7 +48,6 @@ export const COUNTRY_CONFIG: Record<string, CountryConfig> = {
       country: 'US',
       state: 'CA',
       preTax401k: 24500,
-      backdoorRoth: 30000,
       employerMatch: 5,
       filingStatus: 'single'
     },
@@ -75,7 +73,6 @@ export const COUNTRY_CONFIG: Record<string, CountryConfig> = {
       country: 'TW',
       state: '',
       preTax401k: 0,  // Taiwan doesn't use 401k system
-      backdoorRoth: 0,
       employerMatch: 0,
       filingStatus: 'single'
     },


### PR DESCRIPTION
### Motivation
- Backdoor Roth contributions are made with after-tax dollars and should not reduce taxable income, so the calculator must stop treating them as a deduction and the UI input should be removed.

### Description
- Update back-end tax logic in `backend/api/tax.py` so only `pre_tax_401k` reduces federal and state taxable income and removed the `backdoor_roth` parameter.
- Stop reading/passing `backdoorRoth` in the FIRE flow in `backend/api/calculator.py` so tax calls no longer include it.
- Remove the Backdoor Roth field from the frontend `Inputs` model, the Retirement Accounts UI, payload generation, and contribution totals in `src/components/FireCalculator.tsx` and strip it from country defaults in `src/config/countries.ts`.
- Remove obsolete validation for `backdoorRoth` in `backend/api/validation.py` and clean up test payloads in `backend/api/test_calculator.py` that referenced the field.

### Testing
- Ran `pytest backend/api/test_calculator.py backend/api/test_validation.py` and all tests passed (`45 passed`).
- Ran `npm run build` to verify the frontend compiles; the build succeeded (Vite emitted a chunk-size warning but the command completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14c0a64a48323bbbfda5c2d02b109)